### PR TITLE
fix: Disable Symfony deployment workflow for Next.js project

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,6 @@
-name: Deploy
+name: Deploy (Symfony - Disabled for Next.js project)
 on:
-  push: { branches: [ main ] }
+  # push: { branches: [ main ] } - Disabled for Next.js project
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
- Disable automatic trigger for ci.yml workflow (Symfony deployment)
- This workflow is incompatible with our Next.js project
- Next.js deployment should use docker.yml workflow instead
- Prevents SSH secret errors and deployment conflicts

[DISABLE-SYMFONY-CI]