### PR TITLE
fix(prisma): correct v7 configuration - remove url from schema

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -9,7 +9,6 @@ generator client {
 // Database connection is managed by PrismaMariaDb adapter
 datasource db {
   provider = "mysql"
-  url      = env("DATABASE_URL")
 }
 
 model Author {


### PR DESCRIPTION
- Remove url property from schema.prisma datasource (Prisma v7 requirement)
- Keep DATABASE_URL environment variable for migration commands
- Maintain individual DB parameters for PrismaMariaDb adapter

Fixes Prisma v7 validation while preserving migration functionality