### PR TITLE
CRITICAL: fix port configuration - Next.js PORT must be 3000

### DIFF
--- a/docker-compose.final.yml
+++ b/docker-compose.final.yml
@@ -39,7 +39,7 @@ services:
         condition: service_healthy
     environment:
       NODE_ENV: production
-      PORT: "3001"
+      PORT: "3000"                    # Fixed: Next.js runs on internal port 3000
       DATABASE_URL: "mysql://casn_user:casn_password123@mysql:3306/casn"
       DB_HOST: mysql
       DB_PORT: "3306"
@@ -47,13 +47,13 @@ services:
       DB_PASSWORD: casn_password123
       DB_NAME: casn
       NEXTAUTH_SECRET: "your-secret-key-here"
-      NEXTAUTH_URL: "http://localhost:3001"
+      NEXTAUTH_URL: "http://localhost:3001"  # Fixed: External URL uses port 3001
       TZ: Europe/Warsaw
       # Automatic migrations via docker-entrypoint.sh
     ports:
-      - "3001:80"
+      - "3001:3000"                # Fixed: Host port 3001, Container port 3000
     healthcheck:
-      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:3001/api/health >/dev/null 2>&1 || exit 1"]
+      test: ["CMD-SHELL", "wget -qO- http://127.0.0.1:3000/api/health >/dev/null 2>&1 || exit 1"]  # Fixed: Test internal port 3000
       interval: 30s
       timeout: 5s
       retries: 3


### PR DESCRIPTION
- Fix PORT: "3000" (Next.js internal port)
- Fix ports mapping: "3001:3000" (host:container)
- Fix NEXTAUTH_URL: "http://localhost:3001" (external access)
- Fix healthcheck: test internal port 3000
- CRITICAL FIX: Application will only start correctly with PORT 3000 internally