### PR TITLE
fix: remove casn.sql volume mount from docker-compose.portainer.yml

### DIFF
--- a/docker-compose.portainer.yml
+++ b/docker-compose.portainer.yml
@@ -13,7 +13,6 @@ services:
       TZ: Europe/Warsaw
     volumes:
       - mysql_data:/var/lib/mysql
-      - ./casn.sql:/docker-entrypoint-initdb.d/casn.sql:ro
     command: >
       --character-set-server=utf8mb4
       --collation-server=utf8mb4_unicode_ci


### PR DESCRIPTION
- Removed volume mount for casn.sql since it's not accessible in Portainer
- Portainer deployments require manual database import via exec
- Maintains all other production settings and configurations
- Simplifies Portainer deployment workflow