### PR TITLE
fix: make npm start script respect PORT environment variable

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "build": "next build",
     "prebuild": "bash scripts/check-posts.sh",
     "postbuild": "node scripts/prepare-tmp.js",
-    "start": "next start -p 3000",
+    "start": "next start -p $PORT",
     "start:standalone": "node .next/standalone/server.js",
     "lint": "next lint",
     "lint:fix": "next lint --fix",


### PR DESCRIPTION
- Changed 'next start -p 3000' to 'next start -p '
- Allows Docker containers to use correct port from environment
- Fixes port mismatch between docker-compose (port 80) and hardcoded script
- Ensures proper port mapping in production deployments