### PR TITLE
fix: restore PrismaMariaDb adapter in lib/prisma.ts

### DIFF
--- a/lib/prisma.ts
+++ b/lib/prisma.ts
@@ -1,4 +1,13 @@
 import { PrismaClient } from "@prisma/client";
+import { PrismaMariaDb } from "@prisma/adapter-mariadb";
+
+const adapter = new PrismaMariaDb({
+  host: process.env.DB_HOST ?? "mysql",
+  port: Number(process.env.DB_PORT ?? "3306"),
+  user: process.env.DB_USER ?? "casn_user",
+  password: process.env.DB_PASSWORD ?? "casn_password123",
+  database: process.env.DB_NAME ?? "casn",
+});
 
 const globalForPrisma = globalThis as unknown as {
   prisma: PrismaClient | undefined
@@ -8,10 +17,10 @@ let prisma: PrismaClient | undefined
 
 // During build time, create a simple mock
 if (process.env.NEXT_PHASE === 'phase-production-build') {
-  prisma = new PrismaClient();
+  prisma = new PrismaClient({ adapter });
 } else {
   if (!globalForPrisma.prisma) {
-    globalForPrisma.prisma = new PrismaClient();
+    globalForPrisma.prisma = new PrismaClient({ adapter });
   }
   prisma = globalForPrisma.prisma;
 }


### PR DESCRIPTION
- Added back PrismaMariaDb adapter configuration
- Fixes database connection error 'Can't reach database server at localhost:3306'
- Ensures proper connection to MySQL container via environment variables
- Required for Prisma 7.x with MariaDB adapter in Docker environment