### PR TITLE
fix: copy generated Prisma client to Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,6 +67,9 @@ COPY --from=builder --chown=nextjs:nodejs /app/node_modules ./node_modules
 # Copy Prisma files for runtime
 COPY --from=builder --chown=nextjs:nodejs /app/prisma ./prisma
 
+# Copy generated Prisma client
+COPY --from=builder --chown=nextjs:nodejs /app/node_modules/.prisma ./node_modules/.prisma
+
 # Copy MDX posts for runtime loading
 COPY --from=builder --chown=nextjs:nodejs /app/posts ./posts
 


### PR DESCRIPTION
- Add node_modules/.prisma copy to Dockerfile for Prisma runtime
- Ensure Prisma client is available in production container