### PR TITLE
fix: resolve TypeORM Edge Runtime issue with API-first architecture

### DIFF
--- a/app/analizy/[slug]/page.tsx
+++ b/app/analizy/[slug]/page.tsx
@@ -5,7 +5,7 @@ import matter from "gray-matter";
 import ArticleLayout from "@/components/ArticleLayout";
 import Header from "@/components/Header";
 import { notFound } from "next/navigation";
-import { AppDataSource } from "@/lib/db";
+
 import MDXContent from "@/components/mdx/MDXContent";
 
 // ——— RUNTIME / CACHE ————————————————————————————————————————————————
@@ -53,26 +53,22 @@ export default async function Page({ params }: { params: Promise<{ slug: string 
 
     logDbg("STEP", "slug", slug);
 
-    // 1) DB — pobierz meta artykułu (bezpiecznik: nie wywal 500 przy problemie DB)
+    // 1) DB — pobierz meta artykułu via API
     let analysis: any = null;
     try {
-      const analysisRepository = AppDataSource.getRepository('Analysis');
-      analysis = await analysisRepository.findOne({
-        where: { slug },
-        relations: ['author'],
-        select: {
-          id: true,
-          slug: true,
-          title: true,
-          author: {
-            name: true,
-            bio: true,
-          },
-        },
+      const response = await fetch(`http://localhost:3000/api/analyses/${slug}`, {
+        cache: "no-store",
       });
+
+      if (!response.ok) {
+        logDbg("STEP", "notFound_api", slug, response.status);
+        return notFound();
+      }
+
+      analysis = await response.json();
     } catch (e: any) {
-      console.error("DB_ERROR", e?.message || e);
-      // zamiast 500 — 404 (jeśli DB padnie, wolimy "nie znaleziono" niż crash SSR)
+      console.error("API_ERROR", e?.message || e);
+      // zamiast 500 — 404 (jeśli API padnie, wolimy "nie znaleziono" niż crash SSR)
       return notFound();
     }
 

--- a/app/analizy/page.tsx
+++ b/app/analizy/page.tsx
@@ -2,8 +2,6 @@
 import React from "react";
 import Link from "next/link";
 import Image from "next/image";
-import { AppDataSource } from "@/lib/db";
-import { initializeDatabase } from "@/lib/init-db";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -26,21 +24,10 @@ export default async function AnalysesPage() {
   }
 
   try {
-    // Ensure database is initialized
-    if (AppDataSource && !AppDataSource.isInitialized) {
-      await initializeDatabase();
-    }
-
-    if (!AppDataSource || !AppDataSource.isInitialized) {
-      throw new Error('Database not available');
-    }
-
     // Fetch all analyses with author data
-    const analysisRepository = AppDataSource.getRepository('Analysis');
-    const analyses = await analysisRepository.find({
-      relations: ['author'],
-      order: { id: 'DESC' },
-    });
+    const analyses = await fetch("http://localhost:3000/api/analyses", {
+      cache: "no-store",
+    }).then(res => res.json());
 
     return (
       <main className="bg-gray-100 min-h-screen pb-12">
@@ -105,7 +92,7 @@ export default async function AnalysesPage() {
                 </div>
               </div>
             </div>
-            
+
             {analyses.length === 0 ? (
               <div className="row">
                 <div className="col-12 text-center">

--- a/app/api/analyses/[slug]/route.ts
+++ b/app/api/analyses/[slug]/route.ts
@@ -24,25 +24,35 @@ export async function GET(request: Request, { params }: { params: Promise<{ slug
     }
 
     const analysisRepository = AppDataSource.getRepository(AnalysisSchema);
-    const analysis = await analysisRepository.findOne({
-      where: { slug },
-      relations: ['author'],
-      select: {
-        id: true,
-        slug: true,
-        title: true,
-        author: {
-          name: true,
-          bio: true,
-        },
-      },
-    });
+    const analysis = await analysisRepository
+      .createQueryBuilder('analysis')
+      .leftJoin('Author', 'author', 'author.id = analysis.authorId')
+      .select([
+        'analysis.id',
+        'analysis.title',
+        'analysis.slug',
+        'author.name as author_name',
+        'author.bio as author_bio'
+      ])
+      .where('analysis.slug = :slug', { slug })
+      .getRawOne();
 
     if (!analysis) {
       return NextResponse.json({ error: "Analysis not found" }, { status: 404 });
     }
 
-    return NextResponse.json(analysis);
+    // Transform to match expected format
+    const result = {
+      id: analysis.id,
+      title: analysis.title,
+      slug: analysis.slug,
+      author: {
+        name: analysis.author_name,
+        bio: analysis.author_bio,
+      },
+    };
+
+    return NextResponse.json(result);
   } catch (error) {
     console.error('Analysis API error:', error);
     return NextResponse.json({ error: 'Internal server error' }, { status: 500 });

--- a/app/api/analyses/[slug]/route.ts
+++ b/app/api/analyses/[slug]/route.ts
@@ -4,8 +4,10 @@ import { NextResponse } from "next/server";
 import { AppDataSource } from "@/lib/db";
 import { initializeDatabase } from "@/lib/init-db";
 
-export async function GET(request: Request, { params }: { params: { slug: string } }) {
+export async function GET(request: Request, { params }: { params: Promise<{ slug: string }> }) {
   try {
+    const { slug } = await params;
+
     // Skip during build time
     if (process.env.NEXT_PHASE === 'phase-production-build') {
       return NextResponse.json({ error: "Build time - API unavailable" }, { status: 503 });
@@ -22,7 +24,7 @@ export async function GET(request: Request, { params }: { params: { slug: string
 
     const analysisRepository = AppDataSource.getRepository('Analysis');
     const analysis = await analysisRepository.findOne({
-      where: { slug: params.slug },
+      where: { slug },
       relations: ['author'],
       select: {
         id: true,

--- a/app/api/analyses/[slug]/route.ts
+++ b/app/api/analyses/[slug]/route.ts
@@ -3,6 +3,7 @@ export const runtime = "nodejs";
 import { NextResponse } from "next/server";
 import { AppDataSource } from "@/lib/db";
 import { initializeDatabase } from "@/lib/init-db";
+import { AnalysisSchema } from "@/lib/entities";
 
 export async function GET(request: Request, { params }: { params: Promise<{ slug: string }> }) {
   try {
@@ -22,7 +23,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ slug
       return NextResponse.json({ error: "Database not available" }, { status: 503 });
     }
 
-    const analysisRepository = AppDataSource.getRepository('Analysis');
+    const analysisRepository = AppDataSource.getRepository(AnalysisSchema);
     const analysis = await analysisRepository.findOne({
       where: { slug },
       relations: ['author'],

--- a/app/api/analyses/[slug]/route.ts
+++ b/app/api/analyses/[slug]/route.ts
@@ -1,0 +1,47 @@
+export const runtime = "nodejs";
+
+import { NextResponse } from "next/server";
+import { AppDataSource } from "@/lib/db";
+import { initializeDatabase } from "@/lib/init-db";
+
+export async function GET(request: Request, { params }: { params: { slug: string } }) {
+  try {
+    // Skip during build time
+    if (process.env.NEXT_PHASE === 'phase-production-build') {
+      return NextResponse.json({ error: "Build time - API unavailable" }, { status: 503 });
+    }
+
+    // Ensure database is initialized
+    if (AppDataSource && !AppDataSource.isInitialized) {
+      await initializeDatabase();
+    }
+
+    if (!AppDataSource || !AppDataSource.isInitialized) {
+      return NextResponse.json({ error: "Database not available" }, { status: 503 });
+    }
+
+    const analysisRepository = AppDataSource.getRepository('Analysis');
+    const analysis = await analysisRepository.findOne({
+      where: { slug: params.slug },
+      relations: ['author'],
+      select: {
+        id: true,
+        slug: true,
+        title: true,
+        author: {
+          name: true,
+          bio: true,
+        },
+      },
+    });
+
+    if (!analysis) {
+      return NextResponse.json({ error: "Analysis not found" }, { status: 404 });
+    }
+
+    return NextResponse.json(analysis);
+  } catch (error) {
+    console.error('Analysis API error:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/app/api/analyses/route.ts
+++ b/app/api/analyses/route.ts
@@ -3,6 +3,7 @@ export const runtime = "nodejs";
 import { NextResponse } from "next/server";
 import { AppDataSource } from "@/lib/db";
 import { initializeDatabase } from "@/lib/init-db";
+import { AnalysisSchema } from "@/lib/entities";
 
 export async function GET() {
   try {
@@ -20,7 +21,7 @@ export async function GET() {
       return NextResponse.json([]);
     }
 
-    const analysisRepository = AppDataSource.getRepository('Analysis');
+    const analysisRepository = AppDataSource.getRepository(AnalysisSchema);
     const analyses = await analysisRepository.find({
       relations: ['author'],
       order: { id: 'DESC' },

--- a/app/api/analyses/route.ts
+++ b/app/api/analyses/route.ts
@@ -1,0 +1,34 @@
+export const runtime = "nodejs";
+
+import { NextResponse } from "next/server";
+import { AppDataSource } from "@/lib/db";
+import { initializeDatabase } from "@/lib/init-db";
+
+export async function GET() {
+  try {
+    // Skip during build time
+    if (process.env.NEXT_PHASE === 'phase-production-build') {
+      return NextResponse.json([]);
+    }
+
+    // Ensure database is initialized
+    if (AppDataSource && !AppDataSource.isInitialized) {
+      await initializeDatabase();
+    }
+
+    if (!AppDataSource || !AppDataSource.isInitialized) {
+      return NextResponse.json([]);
+    }
+
+    const analysisRepository = AppDataSource.getRepository('Analysis');
+    const analyses = await analysisRepository.find({
+      relations: ['author'],
+      order: { id: 'DESC' },
+    });
+
+    return NextResponse.json(analyses);
+  } catch (error) {
+    console.error('Analyses API error:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/app/api/articles/route.ts
+++ b/app/api/articles/route.ts
@@ -114,9 +114,9 @@ export async function GET() {
             id: item.id,
             title: item.title,
             slug: item.slug,
-            authorId: item.authorId,
-            author_name: item.author.name,
-            author_slug: item.author.slug,
+            authorId: item.authorId as number,
+            author_name: item.author_name,
+            author_slug: item.author_slug,
           }));
         },
         ['articles'],
@@ -147,7 +147,7 @@ export async function GET() {
         id: item.id,
         title: item.title,
         slug: item.slug,
-        authorId: item.authorId,
+        authorId: item.authorId as number,
         author_name: item.author_name,
         author_slug: item.author_slug,
       }));
@@ -214,7 +214,7 @@ export async function POST(req: Request) {
       where: { slug: body.authorSlug },
       select: ['id'],
     });
-    if (author) authorId = author.id;
+    if (author) authorId = author.id as number;
   }
 
   if (!authorId) {
@@ -270,7 +270,7 @@ export async function POST(req: Request) {
     id: articleWithAuthor.id,
     title: articleWithAuthor.title,
     slug: articleWithAuthor.slug,
-    authorId: articleWithAuthor.authorId,
+    authorId: articleWithAuthor.authorId as number,
     author_name: articleWithAuthor.author_name,
     author_slug: articleWithAuthor.author_slug,
   };

--- a/app/api/articles/route.ts
+++ b/app/api/articles/route.ts
@@ -5,6 +5,7 @@ import { NextResponse } from "next/server";
 import { unstable_cache, revalidateTag } from "next/cache";
 import { AppDataSource, isDatabaseConfigured } from "@/lib/db";
 import { initializeDatabase } from "@/lib/init-db";
+import { AuthorSchema, AnalysisSchema } from "@/lib/entities";
 
 // Typy danych
 type ArticleRow = {
@@ -93,7 +94,7 @@ export async function GET() {
     if (typeof unstable_cache !== 'undefined' && process.env.NODE_ENV !== 'test') {
       const getArticlesCached = unstable_cache(
         async () => {
-          const analysisRepository = AppDataSource.getRepository('Analysis');
+          const analysisRepository = AppDataSource.getRepository(AnalysisSchema);
           const data = await analysisRepository
             .createQueryBuilder('analysis')
             .leftJoin('Author', 'author', 'author.id = analysis.authorId')
@@ -127,7 +128,7 @@ export async function GET() {
       articles = await getArticlesCached();
     } else {
       // Direct query for tests or when caching unavailable
-      const analysisRepository = AppDataSource.getRepository('Analysis');
+      const analysisRepository = AppDataSource.getRepository(AnalysisSchema);
       const data = await analysisRepository
         .createQueryBuilder('analysis')
         .leftJoin('Author', 'author', 'author.id = analysis.authorId')
@@ -208,7 +209,7 @@ export async function POST(req: Request) {
       return NextResponse.json({ error: "Database not available" }, { status: 503 });
     }
 
-    const authorRepository = AppDataSource.getRepository('Author');
+    const authorRepository = AppDataSource.getRepository(AuthorSchema);
     const author = await authorRepository.findOne({
       where: { slug: body.authorSlug },
       select: ['id'],
@@ -237,7 +238,7 @@ export async function POST(req: Request) {
     return NextResponse.json({ error: "Database not available" }, { status: 503 });
   }
 
-  const analysisRepository = AppDataSource.getRepository('Analysis');
+  const analysisRepository = AppDataSource.getRepository(AnalysisSchema);
   const newArticle = await analysisRepository.save({
     title,
     slug,

--- a/app/api/authors/[slug]/route.ts
+++ b/app/api/authors/[slug]/route.ts
@@ -3,6 +3,7 @@ export const runtime = "nodejs";
 import { NextResponse } from "next/server";
 import { AppDataSource } from "@/lib/db";
 import { initializeDatabase } from "@/lib/init-db";
+import { AuthorSchema, AnalysisSchema } from "@/lib/entities";
 
 export async function GET(request: Request, { params }: { params: Promise<{ slug: string }> }) {
   try {
@@ -22,7 +23,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ slug
       return NextResponse.json({ error: "Database not available" }, { status: 503 });
     }
 
-    const authorRepository = AppDataSource.getRepository('Author');
+    const authorRepository = AppDataSource.getRepository(AuthorSchema);
     const author = await authorRepository.findOne({
       where: { slug },
     });
@@ -31,7 +32,7 @@ export async function GET(request: Request, { params }: { params: Promise<{ slug
       return NextResponse.json({ error: "Author not found" }, { status: 404 });
     }
 
-    const analysisRepository = AppDataSource.getRepository('Analysis');
+    const analysisRepository = AppDataSource.getRepository(AnalysisSchema);
     const analyses = await analysisRepository.find({
       where: { authorId: author.id },
       order: { id: 'DESC' },

--- a/app/api/authors/[slug]/route.ts
+++ b/app/api/authors/[slug]/route.ts
@@ -1,0 +1,44 @@
+export const runtime = "nodejs";
+
+import { NextResponse } from "next/server";
+import { AppDataSource } from "@/lib/db";
+import { initializeDatabase } from "@/lib/init-db";
+
+export async function GET(request: Request, { params }: { params: { slug: string } }) {
+  try {
+    // Skip during build time
+    if (process.env.NEXT_PHASE === 'phase-production-build') {
+      return NextResponse.json({ error: "Build time - API unavailable" }, { status: 503 });
+    }
+
+    // Ensure database is initialized
+    if (AppDataSource && !AppDataSource.isInitialized) {
+      await initializeDatabase();
+    }
+
+    if (!AppDataSource || !AppDataSource.isInitialized) {
+      return NextResponse.json({ error: "Database not available" }, { status: 503 });
+    }
+
+    const authorRepository = AppDataSource.getRepository('Author');
+    const author = await authorRepository.findOne({
+      where: { slug: params.slug },
+    });
+
+    if (!author) {
+      return NextResponse.json({ error: "Author not found" }, { status: 404 });
+    }
+
+    const analysisRepository = AppDataSource.getRepository('Analysis');
+    const analyses = await analysisRepository.find({
+      where: { authorId: author.id },
+      order: { id: 'DESC' },
+      select: ['id', 'title', 'slug'],
+    });
+
+    return NextResponse.json({ author, analyses });
+  } catch (error) {
+    console.error('Author API error:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/app/api/authors/[slug]/route.ts
+++ b/app/api/authors/[slug]/route.ts
@@ -4,8 +4,10 @@ import { NextResponse } from "next/server";
 import { AppDataSource } from "@/lib/db";
 import { initializeDatabase } from "@/lib/init-db";
 
-export async function GET(request: Request, { params }: { params: { slug: string } }) {
+export async function GET(request: Request, { params }: { params: Promise<{ slug: string }> }) {
   try {
+    const { slug } = await params;
+
     // Skip during build time
     if (process.env.NEXT_PHASE === 'phase-production-build') {
       return NextResponse.json({ error: "Build time - API unavailable" }, { status: 503 });
@@ -22,7 +24,7 @@ export async function GET(request: Request, { params }: { params: { slug: string
 
     const authorRepository = AppDataSource.getRepository('Author');
     const author = await authorRepository.findOne({
-      where: { slug: params.slug },
+      where: { slug },
     });
 
     if (!author) {

--- a/app/api/authors/route.ts
+++ b/app/api/authors/route.ts
@@ -1,0 +1,33 @@
+export const runtime = "nodejs";
+
+import { NextResponse } from "next/server";
+import { AppDataSource } from "@/lib/db";
+import { initializeDatabase } from "@/lib/init-db";
+
+export async function GET() {
+  try {
+    // Skip during build time
+    if (process.env.NEXT_PHASE === 'phase-production-build') {
+      return NextResponse.json([]);
+    }
+
+    // Ensure database is initialized
+    if (AppDataSource && !AppDataSource.isInitialized) {
+      await initializeDatabase();
+    }
+
+    if (!AppDataSource || !AppDataSource.isInitialized) {
+      return NextResponse.json([]);
+    }
+
+    const authorRepository = AppDataSource.getRepository('Author');
+    const authors = await authorRepository.find({
+      order: { name: 'ASC' },
+    });
+
+    return NextResponse.json(authors);
+  } catch (error) {
+    console.error('Authors API error:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/app/api/authors/route.ts
+++ b/app/api/authors/route.ts
@@ -3,6 +3,7 @@ export const runtime = "nodejs";
 import { NextResponse } from "next/server";
 import { AppDataSource } from "@/lib/db";
 import { initializeDatabase } from "@/lib/init-db";
+import { AuthorSchema } from "@/lib/entities";
 
 export async function GET() {
   try {
@@ -20,7 +21,7 @@ export async function GET() {
       return NextResponse.json([]);
     }
 
-    const authorRepository = AppDataSource.getRepository('Author');
+    const authorRepository = AppDataSource.getRepository(AuthorSchema);
     const authors = await authorRepository.find({
       order: { name: 'ASC' },
     });

--- a/app/autor/[slug]/page.tsx
+++ b/app/autor/[slug]/page.tsx
@@ -2,8 +2,6 @@
 import Image from "next/image";
 import Link from "next/link";
 import { notFound } from "next/navigation";
-import { AppDataSource } from "@/lib/db";
-import { initializeDatabase } from "@/lib/init-db";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -17,27 +15,13 @@ export default async function AuthorPage(props: any) {
   const { slug }: { slug: string } = await props.params;
   if (!slug) return notFound();
 
-  // Ensure database is initialized
-  if (AppDataSource && !AppDataSource.isInitialized) {
-    await initializeDatabase();
-  }
-
-  if (!AppDataSource || !AppDataSource.isInitialized) {
-    throw new Error('Database not available');
-  }
-
-  const authorRepository = AppDataSource.getRepository('Author');
-  const author = await authorRepository.findOne({
-    where: { slug },
+  const response = await fetch(`http://localhost:3000/api/authors/${slug}`, {
+    cache: "no-store",
   });
-  if (!author) return notFound();
 
-  const analysisRepository = AppDataSource.getRepository('Analysis');
-  const analyses = await analysisRepository.find({
-    where: { authorId: author.id },
-    order: { id: 'DESC' },
-    select: ['id', 'title', 'slug'],
-  });
+  if (!response.ok) return notFound();
+
+  const { author, analyses } = await response.json();
 
   const imgSrc =
     author.img && (author.img.startsWith("/") || author.img.startsWith("http"))

--- a/app/autorzy/page.tsx
+++ b/app/autorzy/page.tsx
@@ -1,7 +1,6 @@
 import type { Metadata } from "next";
 import Image from "next/image";
 import Link from "next/link";
-import { AppDataSource } from "@/lib/db";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic";
@@ -27,10 +26,9 @@ export default async function AuthorsPage() {
     );
   }
 
-  const authorRepository = AppDataSource.getRepository('Author');
-  const authors = await authorRepository.find({
-    order: { name: 'ASC' },
-  });
+  const authors = await fetch("http://localhost:3000/api/authors", {
+    cache: "no-store",
+  }).then(res => res.json());
 
   const normalizeSrc = (src?: string | null) =>
     src && (src.startsWith("/") || src.startsWith("http"))

--- a/lib/init-db.ts
+++ b/lib/init-db.ts
@@ -4,6 +4,7 @@
 export const runtime = "nodejs";
 
 import { AppDataSource } from './db';
+import { AuthorSchema, AnalysisSchema } from './entities';
 
 // Import entities to ensure they're registered with TypeORM
 import './entities/Author';
@@ -65,8 +66,8 @@ export { AppDataSource };
 
 async function seedDatabaseIfEmpty() {
   try {
-    const authorRepository = AppDataSource.getRepository('Author');
-    const analysisRepository = AppDataSource.getRepository('Analysis');
+    const authorRepository = AppDataSource.getRepository(AuthorSchema);
+    const analysisRepository = AppDataSource.getRepository(AnalysisSchema);
 
     // Check if data already exists
     const authorCount = await authorRepository.count();

--- a/scripts/seed.ts
+++ b/scripts/seed.ts
@@ -1,5 +1,6 @@
 // scripts/seed.ts
 import { AppDataSource } from '@/lib/db';
+import { AuthorSchema, AnalysisSchema } from '@/lib/entities';
 
 async function main() {
   console.log("Starting seed script...");
@@ -10,8 +11,8 @@ async function main() {
     console.log("TypeORM initialized.");
   }
 
-  const authorRepository = AppDataSource.getRepository('Author');
-  const analysisRepository = AppDataSource.getRepository('Analysis');
+  const authorRepository = AppDataSource.getRepository(AuthorSchema);
+  const analysisRepository = AppDataSource.getRepository(AnalysisSchema);
 
   // Check if data already exists
   const authorCount = await authorRepository.count();

--- a/test/integration/db/seed.test.ts
+++ b/test/integration/db/seed.test.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-require-imports */
 import { AppDataSource } from '@/lib/db';
 import { initializeDatabase } from '@/lib/init-db';
+import { AuthorSchema, AnalysisSchema } from '@/lib/entities';
 
 // Ten plik robi prawdziwe I/O (DB + seed), więc musi mieć większy timeout niż domyślne 5s.
 const FILE_TIMEOUT_MS = Number(process.env.JEST_INTEGRATION_TIMEOUT_MS ?? 120_000);
@@ -9,8 +10,8 @@ const TEST_TIMEOUT_MS = Number(process.env.JEST_INTEGRATION_TEST_TIMEOUT_MS ?? 6
 jest.setTimeout(FILE_TIMEOUT_MS);
 
 async function runSeed() {
-  const authorRepository = AppDataSource.getRepository('Author');
-  const analysisRepository = AppDataSource.getRepository('Analysis');
+  const authorRepository = AppDataSource.getRepository(AuthorSchema);
+  const analysisRepository = AppDataSource.getRepository(AnalysisSchema);
 
   // Check if data already exists
   const authorCount = await authorRepository.count();
@@ -68,8 +69,8 @@ describe('Database Seeding', () => {
     'database has proper structure and data after initialization',
     async () => {
       // Database should be initialized and potentially seeded from beforeAll
-      const authorRepository = AppDataSource.getRepository('Author');
-      const analysisRepository = AppDataSource.getRepository('Analysis');
+      const authorRepository = AppDataSource.getRepository(AuthorSchema);
+      const analysisRepository = AppDataSource.getRepository(AnalysisSchema);
 
       // Verify that authors exist
       const authors = await authorRepository.find();
@@ -112,7 +113,7 @@ describe('Database Seeding', () => {
   it(
     'seed script only runs once (idempotent)',
     async () => {
-      const articleRepository = AppDataSource.getRepository('Analysis');
+      const articleRepository = AppDataSource.getRepository(AnalysisSchema);
 
       // Count articles before second seed attempt
       const countBefore = await articleRepository.count();

--- a/test/integration/pages/AuthorPage.test.tsx
+++ b/test/integration/pages/AuthorPage.test.tsx
@@ -6,14 +6,13 @@ jest.mock('next/navigation', () => ({
   notFound: jest.fn(),
 }));
 
+// Mock fetch globally
+global.fetch = jest.fn();
+
 let PageComponent: any;
 let hasComponent = false;
-let AppDataSource: any;
 
 try {
-  // Import modules after setting NODE_ENV
-  const dbModule = require('@/lib/db');
-  AppDataSource = dbModule.AppDataSource;
   PageComponent = require('@/app/autor/[slug]/page').default;
   hasComponent = !!PageComponent;
 } catch {}
@@ -21,45 +20,10 @@ try {
 describe.skip('Author Page', () => {
   const { notFound } = require('next/navigation');
   const mockNotFound = notFound as jest.MockedFunction<typeof notFound>;
+  const mockFetch = global.fetch as jest.MockedFunction<typeof fetch>;
 
-  beforeAll(async () => {
-    // Initialize MySQL database for tests
-    if (!AppDataSource.isInitialized) {
-      console.log('Initializing AppDataSource for tests...');
-      try {
-        await AppDataSource.initialize();
-        console.log('AppDataSource initialized');
-
-        // Run migrations to set up schema
-        console.log('Running migrations...');
-        await AppDataSource.runMigrations();
-        console.log('Migrations completed');
-      } catch (error) {
-        console.warn('Database not available for tests, skipping all tests:', error.message);
-        // Mark as initialized to false so tests are skipped
-        AppDataSource.isInitialized = false;
-        throw new Error('Database not available');
-      }
-    } else {
-      console.log('AppDataSource already initialized');
-    }
-  });
-
-  afterAll(async () => {
-    if (AppDataSource.isInitialized) {
-      await AppDataSource.destroy();
-    }
-  });
-
-  beforeEach(async () => {
+  beforeEach(() => {
     jest.clearAllMocks();
-    // Clear test data
-    if (AppDataSource.isInitialized) {
-      const authorRepo = AppDataSource.getRepository('Author');
-      const analysisRepo = AppDataSource.getRepository('Analysis');
-      await analysisRepo.delete({});
-      await authorRepo.delete({});
-    }
   });
 
   it('wywołuje notFound gdy brakuje slug', async () => {
@@ -71,6 +35,11 @@ describe.skip('Author Page', () => {
   });
 
   it('wywołuje notFound gdy autor nie istnieje', async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+    } as Response);
+
     const props = { params: { slug: 'non-existent-author' } };
 
     await PageComponent(props);
@@ -79,20 +48,23 @@ describe.skip('Author Page', () => {
   });
 
   it('renderuje stronę autora gdy dane są dostępne', async () => {
-    const authorRepository = AppDataSource.getRepository('Author');
-    const analysisRepository = AppDataSource.getRepository('Analysis');
+    const mockAuthorData = {
+      author: {
+        slug: 'test-author',
+        name: 'Jan Kowalski',
+        bio: 'Ekspert w dziedzinie analiz politycznych',
+        img: '/images/author.jpg'
+      },
+      analyses: [
+        { title: 'Analiza 1', slug: 'analiza-1', id: 1 },
+        { title: 'Analiza 2', slug: 'analiza-2', id: 2 },
+      ]
+    };
 
-    const author = await authorRepository.save({
-      slug: 'test-author',
-      name: 'Jan Kowalski',
-      bio: 'Ekspert w dziedzinie analiz politycznych',
-      img: '/images/author.jpg'
-    });
-
-    await analysisRepository.save([
-      { title: 'Analiza 1', slug: 'analiza-1', authorId: author.id },
-      { title: 'Analiza 2', slug: 'analiza-2', authorId: author.id },
-    ]);
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockAuthorData,
+    } as Response);
 
     const props = { params: { slug: 'test-author' } };
 
@@ -108,21 +80,22 @@ describe.skip('Author Page', () => {
   });
 
   it('renderuje prawidłowe linki do analiz autora', async () => {
-    const authorRepository = AppDataSource.getRepository('Author');
-    const analysisRepository = AppDataSource.getRepository('Analysis');
+    const mockAuthorData = {
+      author: {
+        slug: 'test-author',
+        name: 'Test Author',
+        bio: 'Bio text',
+        img: '/images/test.jpg'
+      },
+      analyses: [
+        { title: 'Test Analysis', slug: 'test-analysis', id: 1 },
+      ]
+    };
 
-    const author = await authorRepository.save({
-      slug: 'test-author',
-      name: 'Test Author',
-      bio: 'Bio text',
-      img: '/images/test.jpg'
-    });
-
-    await analysisRepository.save({
-      title: 'Test Analysis',
-      slug: 'test-analysis',
-      authorId: author.id
-    });
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockAuthorData,
+    } as Response);
 
     const props = { params: { slug: 'test-author' } };
 
@@ -137,15 +110,21 @@ describe.skip('Author Page', () => {
   });
 
   it('renderuje obraz autora lub placeholder', async () => {
-    const authorRepository = AppDataSource.getRepository('Author');
-
     // Test with image
-    await authorRepository.save({
-      slug: 'author-with-image',
-      name: 'Author With Image',
-      bio: 'Bio',
-      img: '/images/author.jpg'
-    });
+    const mockAuthorWithImage = {
+      author: {
+        slug: 'author-with-image',
+        name: 'Author With Image',
+        bio: 'Bio',
+        img: '/images/author.jpg'
+      },
+      analyses: []
+    };
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockAuthorWithImage,
+    } as Response);
 
     const props1 = { params: { slug: 'author-with-image' } };
     const { rerender } = render(await PageComponent(props1));
@@ -156,12 +135,20 @@ describe.skip('Author Page', () => {
     });
 
     // Test without image
-    await authorRepository.save({
-      slug: 'author-without-image',
-      name: 'Author Without Image',
-      bio: 'Bio',
-      img: null
-    });
+    const mockAuthorWithoutImage = {
+      author: {
+        slug: 'author-without-image',
+        name: 'Author Without Image',
+        bio: 'Bio',
+        img: null
+      },
+      analyses: []
+    };
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockAuthorWithoutImage,
+    } as Response);
 
     const props2 = { params: { slug: 'author-without-image' } };
     rerender(await PageComponent(props2));
@@ -173,14 +160,20 @@ describe.skip('Author Page', () => {
   });
 
   it('renderuje hero sekcję z breadcrumb', async () => {
-    const authorRepository = AppDataSource.getRepository('Author');
+    const mockAuthorData = {
+      author: {
+        slug: 'test-author',
+        name: 'Test Author',
+        bio: 'Bio',
+        img: '/images/test.jpg'
+      },
+      analyses: []
+    };
 
-    await authorRepository.save({
-      slug: 'test-author',
-      name: 'Test Author',
-      bio: 'Bio',
-      img: '/images/test.jpg'
-    });
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockAuthorData,
+    } as Response);
 
     const props = { params: { slug: 'test-author' } };
 
@@ -195,21 +188,22 @@ describe.skip('Author Page', () => {
   });
 
   it('renderuje sekcję artykułów tylko gdy autor ma analizy', async () => {
-    const authorRepository = AppDataSource.getRepository('Author');
-    const analysisRepository = AppDataSource.getRepository('Analysis');
+    const mockAuthorData = {
+      author: {
+        slug: 'test-author',
+        name: 'Test Author',
+        bio: 'Bio',
+        img: '/images/test.jpg'
+      },
+      analyses: [
+        { title: 'Analysis 1', slug: 'analysis-1', id: 1 },
+      ]
+    };
 
-    const author = await authorRepository.save({
-      slug: 'test-author',
-      name: 'Test Author',
-      bio: 'Bio',
-      img: '/images/test.jpg'
-    });
-
-    await analysisRepository.save({
-      title: 'Analysis 1',
-      slug: 'analysis-1',
-      authorId: author.id
-    });
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockAuthorData,
+    } as Response);
 
     const props = { params: { slug: 'test-author' } };
     const { container } = render(await PageComponent(props));
@@ -221,14 +215,20 @@ describe.skip('Author Page', () => {
   });
 
   it('nie renderuje sekcji artykułów gdy autor nie ma analiz', async () => {
-    const authorRepository = AppDataSource.getRepository('Author');
+    const mockAuthorData = {
+      author: {
+        slug: 'test-author',
+        name: 'Test Author',
+        bio: 'Bio',
+        img: '/images/test.jpg'
+      },
+      analyses: []
+    };
 
-    await authorRepository.save({
-      slug: 'test-author',
-      name: 'Test Author',
-      bio: 'Bio',
-      img: '/images/test.jpg'
-    });
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockAuthorData,
+    } as Response);
 
     const props = { params: { slug: 'test-author' } };
     const { container } = render(await PageComponent(props));
@@ -242,14 +242,20 @@ describe.skip('Author Page', () => {
   });
 
   it('renderuje biogram autora', async () => {
-    const authorRepository = AppDataSource.getRepository('Author');
+    const mockAuthorData = {
+      author: {
+        slug: 'test-author',
+        name: 'Test Author',
+        bio: 'To jest przykładowy biogram autora z wieloma informacjami.',
+        img: '/images/test.jpg'
+      },
+      analyses: []
+    };
 
-    await authorRepository.save({
-      slug: 'test-author',
-      name: 'Test Author',
-      bio: 'To jest przykładowy biogram autora z wieloma informacjami.',
-      img: '/images/test.jpg'
-    });
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockAuthorData,
+    } as Response);
 
     const props = { params: { slug: 'test-author' } };
 
@@ -261,14 +267,20 @@ describe.skip('Author Page', () => {
   });
 
   it('renderuje pusty biogram gdy nie jest dostępny', async () => {
-    const authorRepository = AppDataSource.getRepository('Author');
+    const mockAuthorData = {
+      author: {
+        slug: 'test-author',
+        name: 'Test Author',
+        bio: null,
+        img: '/images/test.jpg'
+      },
+      analyses: []
+    };
 
-    await authorRepository.save({
-      slug: 'test-author',
-      name: 'Test Author',
-      bio: null,
-      img: '/images/test.jpg'
-    });
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockAuthorData,
+    } as Response);
 
     const props = { params: { slug: 'test-author' } };
 
@@ -282,14 +294,20 @@ describe.skip('Author Page', () => {
   });
 
   it('ma odpowiednie klasy CSS dla layout', async () => {
-    const authorRepository = AppDataSource.getRepository('Author');
+    const mockAuthorData = {
+      author: {
+        slug: 'test-author',
+        name: 'Test Author',
+        bio: 'Bio',
+        img: '/images/test.jpg'
+      },
+      analyses: []
+    };
 
-    await authorRepository.save({
-      slug: 'test-author',
-      name: 'Test Author',
-      bio: 'Bio',
-      img: '/images/test.jpg'
-    });
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => mockAuthorData,
+    } as Response);
 
     const props = { params: { slug: 'test-author' } };
     const { container } = render(await PageComponent(props));


### PR DESCRIPTION
- Move database access from Server Components to API routes
- Create /api/authors and /api/analyses endpoints with nodejs runtime
- Update 4 Server Components to use fetch() instead of direct DB imports
- Update tests to mock API responses instead of database operations
- Prevent TypeORM from being bundled in Edge runtime

Fixes MySQL connection errors in Next.js Edge Runtime