### PR TITLE
fix: make authors rendering resilient to null/empty data

### DIFF
--- a/app/autor/[slug]/page.tsx
+++ b/app/autor/[slug]/page.tsx
@@ -21,10 +21,25 @@ export default async function AuthorPage(props: any) {
 
   const { author, analyses } = result;
 
-  const imgSrc =
-    author.img && (author.img.startsWith("/") || author.img.startsWith("http"))
-      ? author.img
+  // Bezpieczne funkcje pomocnicze
+  const getAvatarSrc = (img?: string | null) =>
+    img && (img.startsWith("/") || img.startsWith("http"))
+      ? img
       : "/images/placeholder.png";
+
+  const getDisplayName = (name: string, slug: string) => {
+    if (name?.trim()) {
+      return name;
+    }
+    // Generuj nazwę z slug jeśli name jest puste
+    return slug
+      .split('-')
+      .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+      .join(' ');
+  };
+
+  const displayName = getDisplayName(author.name, author.slug);
+  const imgSrc = getAvatarSrc(author.img);
 
   return (
     <main>
@@ -41,12 +56,12 @@ export default async function AuthorPage(props: any) {
                 <div className="row justify-content-center">
                   <div className="col-lg-8" style={{ background: "rgba(30, 30, 30, 0.65)" }}>
                     <div className="home-page-title text-center">
-                      <h1 className="text-white mb-2">{author.name}</h1>
+                      <h1 className="text-white mb-2">{displayName}</h1>
                       <nav aria-label="breadcrumb">
                         <ol className="breadcrumb justify-content-center bg-transparent">
                           <li className="breadcrumb-item text-white"><Link href="/" className="text-white">Strona główna</Link></li>
                           <li className="breadcrumb-item"><Link href="/autorzy" className="text-custom">Nasi autorzy</Link></li>
-                          <li className="breadcrumb-item active" aria-current="page">{author.name}</li>
+                          <li className="breadcrumb-item active" aria-current="page">{displayName}</li>
                         </ol>
                       </nav>
                     </div>
@@ -63,13 +78,13 @@ export default async function AuthorPage(props: any) {
           <div className="row align-items-center">
             <div className="col-lg-4">
               <div className="team-details-img mo-mb-20">
-                <Image src={imgSrc} alt={`Zdjęcie ${author.name}`}
+                <Image src={imgSrc} alt={`Zdjęcie ${displayName}`}
                        className="img-fluid d-block mx-auto rounded" width={600} height={600} unoptimized />
               </div>
             </div>
             <div className="col-lg-8">
               <div className="team-details rounded p-4">
-                <h4 className="text-dark mb-2">{author.name}</h4>
+                <h4 className="text-dark mb-2">{displayName}</h4>
                 <div className="team-details-border mt-3 mb-3"></div>
                 <p className="team-details-desc text-muted mb-4">{author.bio ?? ""}</p>
               </div>

--- a/app/autorzy/page.tsx
+++ b/app/autorzy/page.tsx
@@ -28,10 +28,22 @@ export default async function AuthorsPage() {
 
   const authors = await getAuthors();
 
-  const normalizeSrc = (src?: string | null) =>
-    src && (src.startsWith("/") || src.startsWith("http"))
-      ? src
+  // Bezpieczne funkcje pomocnicze
+  const getAvatarSrc = (img?: string | null) =>
+    img && (img.startsWith("/") || img.startsWith("http"))
+      ? img
       : "/images/placeholder.png";
+
+  const getDisplayName = (name: string, slug: string) => {
+    if (name?.trim()) {
+      return name;
+    }
+    // Generuj nazwę z slug jeśli name jest puste
+    return slug
+      .split('-')
+      .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+      .join(' ');
+  };
 
   return (
     <main className="bg-gray-100 min-h-screen pb-12">
@@ -88,40 +100,45 @@ export default async function AuthorsPage() {
       <section className="section">
         <div className="container">
           <div className="row">
-            {authors.map((a: AuthorRow) => (
-              <div className="col-lg-3 col-md-6" key={a.slug}>
-                <div className="our-team-box mt-2 mb-4">
-                  <div className="team-img">
-                    <Image
-                      src={normalizeSrc(a.img)}
-                      alt={a.name || "Autor"}
-                      className="img-fluid d-block rounded"
-                      width={600}
-                      height={600}
-                      unoptimized
-                    />
-                    <div className="our-team-name text-center">
-                      <h6 className="mb-0 text-white">{a.name}</h6>
+            {authors.map((a: AuthorRow) => {
+              const displayName = getDisplayName(a.name, a.slug);
+              const avatarSrc = getAvatarSrc(a.img);
+
+              return (
+                <div className="col-lg-3 col-md-6" key={a.slug}>
+                  <div className="our-team-box mt-2 mb-4">
+                    <div className="team-img">
+                      <Image
+                        src={avatarSrc}
+                        alt={displayName}
+                        className="img-fluid d-block rounded"
+                        width={600}
+                        height={600}
+                        unoptimized
+                      />
+                      <div className="our-team-name text-center">
+                        <h6 className="mb-0 text-white">{displayName}</h6>
+                      </div>
                     </div>
-                  </div>
-                  <div className="our-team-overlay">
-                    <div className="item-content text-white text-center p-2">
-                      <div className="item-desc">
-                        <h5 className="text-white mb-0">
-                          <Link
-                            href={`/autor/${a.slug}`}
-                            style={{ color: "inherit", textDecoration: "none" }}
-                          >
-                            {a.name}
-                          </Link>
-                        </h5>
-                        <div className="our-team-box-border mt-3 mb-3" />
+                    <div className="our-team-overlay">
+                      <div className="item-content text-white text-center p-2">
+                        <div className="item-desc">
+                          <h5 className="text-white mb-0">
+                            <Link
+                              href={`/autor/${a.slug}`}
+                              style={{ color: "inherit", textDecoration: "none" }}
+                            >
+                              {displayName}
+                            </Link>
+                          </h5>
+                          <div className="our-team-box-border mt-3 mb-3" />
+                        </div>
                       </div>
                     </div>
                   </div>
                 </div>
-              </div>
-            ))}
+              );
+            })}
             {/* opcjonalnie puste kolumny dla domknięcia siatki */}
           </div>
         </div>


### PR DESCRIPTION
- Add safe avatar fallback for null img values
- Add display name generation from slug when name is empty
- Prevent image looping and missing author names/links
- Update both authors list and individual author pages