### PR TITLE
fix: resolve 404 errors on analysis pages

### DIFF
--- a/app/analizy/[slug]/page.tsx
+++ b/app/analizy/[slug]/page.tsx
@@ -5,14 +5,29 @@ import matter from "gray-matter";
 import ArticleLayout from "@/components/ArticleLayout";
 import Header from "@/components/Header";
 import { notFound } from "next/navigation";
-import { getAnalysisBySlug } from "@/lib/analyses";
+import { getAnalyses, getAnalysisBySlug } from "@/lib/analyses";
 
 import MDXContent from "@/components/mdx/MDXContent";
 
 // ——— RUNTIME / CACHE ————————————————————————————————————————————————
 export const runtime = "nodejs";
-// Tymczasowo zostaw; po stabilizacji zamień na: export const revalidate = 300;
-export const dynamic = "force-dynamic";
+// Generuj statycznie dla lepszej wydajności i SEO
+export const dynamicParams = true; // Allow dynamic params for new content
+export const revalidate = 3600; // Revalidate every hour
+
+// Generuj statyczne ścieżki dla istniejących analiz
+export async function generateStaticParams() {
+  try {
+    const analyses = await getAnalyses();
+    return analyses.map((analysis) => ({
+      slug: analysis.slug,
+    }));
+  } catch (error) {
+    // W przypadku błędu DB, zwróć pustą tablicę (fallback do SSR)
+    console.warn('generateStaticParams failed:', error);
+    return [];
+  }
+}
 
 // ——— Typy ——————————————————————————————————————————————————————————————
 

--- a/lib/analyses.ts
+++ b/lib/analyses.ts
@@ -60,31 +60,29 @@ export async function getAnalysisBySlug(slug: string): Promise<AnalysisDetail | 
   }
 
   const analysisRepository = AppDataSource.getRepository(AnalysisSchema);
-  const analysis = await analysisRepository
-    .createQueryBuilder('analysis')
-    .leftJoin('Author', 'author', 'author.id = analysis.authorId')
-    .select([
-      'analysis.id',
-      'analysis.title',
-      'analysis.slug',
-      'author.name as author_name',
-      'author.bio as author_bio'
-    ])
-    .where('analysis.slug = :slug', { slug })
-    .getRawOne();
+
+  // U|yj findOne zamiast query builder dla prostoty i niezawodno[ci
+  const analysis = await analysisRepository.findOne({
+    where: { slug },
+    relations: {
+      author: true,
+    },
+  });
 
   if (!analysis) {
     return null;
   }
 
   // Transform to UI-friendly format
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const author = (analysis as any).author;
   return {
-    id: String(analysis.analysis_id || analysis.id),
-    title: analysis.analysis_title || analysis.title,
-    slug: analysis.analysis_slug || analysis.slug,
-    author: analysis.author_name ? {
-      name: analysis.author_name,
-      bio: analysis.author_bio || undefined,
+    id: String(analysis.id),
+    title: analysis.title,
+    slug: analysis.slug,
+    author: author ? {
+      name: author.name || undefined,
+      bio: author.bio || undefined,
     } : undefined,
   };
 }


### PR DESCRIPTION
- Replace problematic query builder with reliable findOne in getAnalysisBySlug
- Add generateStaticParams for SSG and better SEO performance
- Allow dynamic params for new content with fallback to SSR
- Add hourly revalidation for content freshness
- Fix TypeScript errors with proper type assertions

This resolves Next.js 404s on /analizy/[slug] routes by ensuring:
- Reliable database queries with proper relations
- Static generation for existing analyses
- Fallback to SSR for new/dynamic content