### PR TITLE
fix: use stable key prop to prevent hydration mismatch

### DIFF
--- a/app/autorzy/page.tsx
+++ b/app/autorzy/page.tsx
@@ -109,7 +109,7 @@ export default async function AuthorsPage() {
               const avatarSrc = getAvatarSrc(a.img);
 
               return (
-                <div className="col-lg-3 col-md-6" key={a.slug}>
+                <div className="col-lg-3 col-md-6" key={a.id}>
                   <div className="our-team-box mt-2 mb-4">
                     <div className="team-img">
                       <Image


### PR DESCRIPTION
- Change React key from slug to id for stable element identification
- Prevents hydration mismatch when slug values differ between SSR and client
- key={a.id} ensures consistent DOM reconciliation during hydration

This fixes the root cause of React error #418 by providing stable, predictable keys that don't change between server and client rendering.