### PR TITLE
fix: clear TypeScript cache in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -57,6 +57,9 @@ jobs:
             npm install
           fi
 
+      - name: Clear TypeScript cache
+        run: rm -rf node_modules/.cache tsconfig.tsbuildinfo tsconfig.ci.tsbuildinfo
+
       - name: Wait for MySQL
         run: |
           while ! mysqladmin ping -h"127.0.0.1" -P"3306" --silent; do


### PR DESCRIPTION
- Add cache clearing step before type-check in deploy.yml
- Prevents stale references to deleted prisma/seed.ts file
- Ensures clean TypeScript compilation in CI/CD on main branch