### PR TITLE
fix: add CodeQL configuration to exclude problematic files

### DIFF
--- a/codeql-config.yml
+++ b/codeql-config.yml
@@ -1,0 +1,31 @@
+name: "CodeQL Configuration"
+
+disable-default-queries: false
+
+queries:
+  - exclude:
+      - "**/node_modules/**"
+      - "**/prisma/**"
+      - "**/.next/**"
+      - "**/cypress/**"
+      - "**/*.cy.ts"
+      - "**/*.cy.tsx"
+      - "**/*.test.ts"
+      - "**/*.test.tsx"
+      - "**/*.spec.ts"
+      - "**/*.spec.tsx"
+
+paths:
+  - src
+  - app
+  - lib
+  - scripts
+  - types
+
+paths-ignore:
+  - node_modules
+  - .next
+  - cypress
+  - prisma
+  - "**/*.config.*"
+  - "**/*.setup.*"


### PR DESCRIPTION
- Create codeql-config.yml to exclude node_modules, prisma, test files
- Prevents CodeQL from analyzing files with syntax errors or missing references
- Should resolve CodeQL warnings about TypeScript parsing errors