### PR TITLE
fix: update SafeImage tests for simplified component

### DIFF
--- a/test/unit/components/SafeImage.test.tsx
+++ b/test/unit/components/SafeImage.test.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/no-require-imports, @typescript-eslint/no-explicit-any */
 
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 
 let SafeImage: any;
 let hasComp = false;
@@ -10,83 +10,16 @@ try {
 } catch (e) {}
 
 (hasComp ? describe : describe.skip)('SafeImage', () => {
-  // Mock Image constructor
-  const mockImage = {
-    onload: jest.fn(),
-    onerror: jest.fn(),
-    src: ''
-  };
+  it('renderuje img element z podanymi props', () => {
+    render(<SafeImage src="/test.jpg" alt="Test image" />);
 
-  beforeEach(() => {
-    // Reset mocks
-    jest.clearAllMocks();
-    global.Image = jest.fn().mockImplementation(() => mockImage);
-  });
-
-  it('renderuje obraz gdy się ładuje poprawnie', async () => {
-    render(<SafeImage src="/test-image.jpg" alt="Test image" />);
-
-    // Initially should render the img element
     const img = screen.getByAltText('Test image');
     expect(img).toBeInTheDocument();
-    expect(img).toHaveAttribute('src', '/test-image.jpg');
-
-    // Trigger successful load
-    await waitFor(() => {
-      mockImage.onload();
-    });
-
-    // Should still render the img
-    expect(screen.getByAltText('Test image')).toBeInTheDocument();
+    expect(img).toHaveAttribute('src', '/test.jpg');
+    expect(img.tagName).toBe('IMG');
   });
 
-  it('renderuje fallback gdy obraz się nie załaduje', async () => {
-    render(<SafeImage src="/broken-image.jpg" alt="Broken image" />);
-
-    // Initially should render the img element
-    expect(screen.getByAltText('Broken image')).toBeInTheDocument();
-
-    // Trigger error
-    mockImage.onerror();
-
-    await waitFor(() => {
-      expect(screen.getByText('Obraz niedostępny')).toBeInTheDocument();
-    });
-
-    // Original img should be gone
-    expect(screen.queryByAltText('Broken image')).not.toBeInTheDocument();
-  });
-
-  it('renderuje fallback gdy timeout zostanie przekroczony', async () => {
-    render(<SafeImage src="/slow-image.jpg" alt="Slow image" timeoutMs={100} />);
-
-    // Initially should render the img element
-    expect(screen.getByAltText('Slow image')).toBeInTheDocument();
-
-    // Wait for timeout
-    await waitFor(() => {
-      expect(screen.getByText('Obraz niedostępny')).toBeInTheDocument();
-    }, { timeout: 200 });
-
-    // Original img should be gone
-    expect(screen.queryByAltText('Slow image')).not.toBeInTheDocument();
-  });
-
-  it('używa domyślnego timeout 7000ms', () => {
-    render(<SafeImage src="/test.jpg" alt="Test" />);
-
-    expect(global.Image).toHaveBeenCalledTimes(1);
-    expect(mockImage.src).toBe('/test.jpg');
-  });
-
-  it('używa customowego timeout', () => {
-    render(<SafeImage src="/test.jpg" alt="Test" timeoutMs={5000} />);
-
-    expect(global.Image).toHaveBeenCalledTimes(1);
-    expect(mockImage.src).toBe('/test.jpg');
-  });
-
-  it('przekazuje pozostałe props do img elementu', () => {
+  it('przekazuje wszystkie props do img elementu', () => {
     render(
       <SafeImage
         src="/test.jpg"
@@ -94,6 +27,7 @@ try {
         className="custom-class"
         width={100}
         height={50}
+        data-testid="custom-image"
       />
     );
 
@@ -101,6 +35,7 @@ try {
     expect(img).toHaveClass('custom-class');
     expect(img).toHaveAttribute('width', '100');
     expect(img).toHaveAttribute('height', '50');
+    expect(img).toHaveAttribute('data-testid', 'custom-image');
   });
 
   it('używa domyślnego alt text gdy nie podany', () => {
@@ -108,13 +43,22 @@ try {
 
     const img = screen.getByAltText('');
     expect(img).toBeInTheDocument();
+    expect(img).toHaveAttribute('src', '/test.jpg');
   });
 
   it('konwertuje src na string', () => {
     render(<SafeImage src={123 as any} alt="Test" />);
 
-    expect(mockImage.src).toBe('123');
     const img = screen.getByAltText('Test');
     expect(img).toHaveAttribute('src', '123');
+  });
+
+  it('renderuje się jako standardowy img element', () => {
+    render(<SafeImage src="/test.jpg" alt="Test" />);
+
+    const img = screen.getByAltText('Test');
+    expect(img.tagName).toBe('IMG');
+    expect(img).toHaveAttribute('src');
+    expect(img).toHaveAttribute('alt');
   });
 });


### PR DESCRIPTION
- Remove complex Image mocking and timeout logic tests
- Update tests to match new simple img wrapper implementation
- Remove act() warnings by eliminating async client-side logic
- Focus on testing props forwarding and basic img element rendering

Applied directly to dev branch without merging from main.