### PR TITLE
fix: napraw błąd React #418 - nieprawidłowe dzieci komponentów

### DIFF
--- a/app/autor/[slug]/page.tsx
+++ b/app/autor/[slug]/page.tsx
@@ -79,7 +79,7 @@ export default async function AuthorPage(props: any) {
         </div>
       </section>
 
-      {!!analyses.length && (
+      {analyses.length > 0 ? (
         <section className="section bg-light">
           <div className="container">
             <div className="row">
@@ -98,7 +98,7 @@ export default async function AuthorPage(props: any) {
             </div>
           </div>
         </section>
-      )}
+      ) : null}
     </main>
   );
 }

--- a/app/autorzy/page.tsx
+++ b/app/autorzy/page.tsx
@@ -21,7 +21,8 @@ function AuthorsGrid({ authors }: { authors: AuthorRow[] }) {
     <section className="section">
       <div className="container">
         <div className="row">
-          {authors.map((a: AuthorRow) => {
+          {authors.length > 0 ? (
+          authors.map((a: AuthorRow) => {
             const avatarSrc = getAvatarSrc(a.img);
 
             return (
@@ -60,12 +61,12 @@ function AuthorsGrid({ authors }: { authors: AuthorRow[] }) {
                 </div>
               </div>
             );
-          })}
-          {authors.length === 0 && (
-            <div className="col-12 text-center py-5">
-              <p className="text-muted">Autorzy będą wkrótce dodani.</p>
-            </div>
-          )}
+          })
+        ) : (
+          <div className="col-12 text-center py-5">
+            <p className="text-muted">Autorzy będą wkrótce dodani.</p>
+          </div>
+        )}
         </div>
       </div>
     </section>


### PR DESCRIPTION
- Zmieniono warunkowe renderowanie z && na ternary operator w AuthorsGrid
- Naprawiono podobny wzorzec w AuthorPage dla sekcji artykułów
- Zapewnia spójne zwracanie JSX zamiast mieszanki tablic i wyrażeń warunkowych