### PR TITLE
fix: completely remove legacy CSS imports causing hydration errors

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1,14 +1,5 @@
 @import "bootstrap/dist/css/bootstrap.min.css";
 
-/* Legacy - CSS syntax errors fixed */
-@import "css/legacy/magnific-popup.css";
-@import "css/legacy/menu.css";
-@import "css/legacy/owl.carousel.css";
-@import "css/legacy/owl.theme.css";
-@import "css/legacy/owl.transitions.css";
-@import "css/legacy/style.css";
-@import "css/legacy/themify-icons.css";
-
 /* Reset & base */
 html,
 body {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -62,7 +62,7 @@ export const metadata = {
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {
   return (
-    <html lang="pl" className={`${roboto.variable} ${rubik.variable}`} suppressHydrationWarning>
+    <html lang="pl" className={`${roboto.variable} ${rubik.variable}`}>
       <body className="bg-white text-black">
         <Header />
         <main className="w-full min-h-screen">{children}</main>


### PR DESCRIPTION
- Removed all legacy CSS imports from globals.css (magnific-popup, owl, themify-icons, etc.)
- Removed suppressHydrationWarning since root cause is fixed
- Legacy CSS contained IE filters and styles causing text node mismatches
- Should eliminate React error #418 completely