### PR TITLE
fix: temporarily enable TypeORM synchronize to create missing databas…

### DIFF
--- a/lib/db.server.ts
+++ b/lib/db.server.ts
@@ -63,7 +63,7 @@ if (databaseUrl) {
     username: process.env.DB_USER || 'root',
     password: process.env.DB_PASSWORD || '',
     database: process.env.DB_NAME || 'casn',
-    synchronize: false, // Never synchronize - use migrations
+    synchronize: true, // TEMPORARY: Enable auto-sync to create missing tables
     logging: !isProduction,
     // Remove charset/collation to use MySQL defaults and avoid encoding conflicts
   };


### PR DESCRIPTION
…e tables

CRITICAL FIX: Database tables (Author, Analysis) don't exist in production container because migrations are missing from the build. This causes API to return ER_NO_SUCH_TABLE errors and frontend to show fallback messages.

TEMPORARY SOLUTION: Enable synchronize: true to auto-create tables on startup. This confirms frontend + API work correctly and unblocks the project.

TODO: Replace with proper migration strategy for production deployment.