### PR TITLE
fix: ensure database migrations run on first API request

### DIFF
--- a/app/api/analyses/route.ts
+++ b/app/api/analyses/route.ts
@@ -2,7 +2,7 @@ export const runtime = "nodejs";
 
 import { NextResponse } from "next/server";
 import { AppDataSource } from "@/lib/db.server";
-import { initializeDatabase } from "@/lib/init-db";
+import { initDatabase } from "@/lib/server/db";
 import { AnalysisSchema } from "@/lib/entities";
 
 export async function GET() {
@@ -13,9 +13,7 @@ export async function GET() {
     }
 
     // Ensure database is initialized
-    if (AppDataSource && !AppDataSource.isInitialized) {
-      await initializeDatabase();
-    }
+    await initDatabase();
 
     if (!AppDataSource || !AppDataSource.isInitialized) {
       return NextResponse.json([]);

--- a/app/api/articles/route.ts
+++ b/app/api/articles/route.ts
@@ -4,7 +4,7 @@ export const runtime = "nodejs";
 import { NextResponse } from "next/server";
 import { unstable_cache, revalidateTag } from "next/cache";
 import { AppDataSource, isDatabaseConfigured } from "@/lib/db.server";
-import { initializeDatabase } from "@/lib/server/init-db";
+import { initDatabase } from "@/lib/server/db";
 import { AuthorSchema, AnalysisSchema } from "@/lib/entities";
 
 // Typy danych
@@ -65,9 +65,7 @@ export async function GET() {
 
     // Ensure database is initialized
     try {
-      if (AppDataSource && !AppDataSource.isInitialized) {
-        await initializeDatabase();
-      }
+      await initDatabase();
     } catch (error) {
       console.error('Database initialization failed in GET:', error);
       return NextResponse.json([], {
@@ -197,9 +195,7 @@ export async function POST(req: Request) {
   } else if (isBodyWithSlug(body)) {
     // Ensure database is initialized
     try {
-      if (AppDataSource && !AppDataSource.isInitialized) {
-        await initializeDatabase();
-      }
+      await initDatabase();
     } catch (error) {
       console.error('Database initialization failed in POST:', error);
       return NextResponse.json({ error: "Database not available" }, { status: 503 });
@@ -226,9 +222,7 @@ export async function POST(req: Request) {
 
   // Ensure database is initialized for saving
   try {
-    if (AppDataSource && !AppDataSource.isInitialized) {
-      await initializeDatabase();
-    }
+    await initDatabase();
   } catch (error) {
     console.error('Database initialization failed in POST save:', error);
     return NextResponse.json({ error: "Database not available" }, { status: 503 });

--- a/app/api/authors/route.ts
+++ b/app/api/authors/route.ts
@@ -2,7 +2,7 @@ export const runtime = "nodejs";
 
 import { NextResponse } from "next/server";
 import { AppDataSource } from "@/lib/db.server";
-import { initializeDatabase } from "@/lib/init-db";
+import { initDatabase } from "@/lib/server/db";
 import { AuthorSchema } from "@/lib/entities";
 
 export async function GET() {
@@ -13,9 +13,7 @@ export async function GET() {
     }
 
     // Ensure database is initialized
-    if (AppDataSource && !AppDataSource.isInitialized) {
-      await initializeDatabase();
-    }
+    await initDatabase();
 
     if (!AppDataSource || !AppDataSource.isInitialized) {
       return NextResponse.json([]);

--- a/app/api/db-init/route.ts
+++ b/app/api/db-init/route.ts
@@ -1,4 +1,4 @@
-import { initializeDatabase } from '@/lib/init-db';
+import { initDatabase } from '@/lib/server/db';
 import { AppDataSource } from '@/lib/db.server';
 import { NextResponse } from 'next/server';
 
@@ -6,9 +6,9 @@ export async function GET() {
   try {
     console.log('🚀 Manual database initialization triggered via API');
 
-    const result = await initializeDatabase();
+    await initDatabase();
 
-    if (result) {
+    if (AppDataSource?.isInitialized) {
       return NextResponse.json({
         success: true,
         message: 'Database initialization completed successfully',

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,4 +1,4 @@
-import { initializeDatabase } from '@/lib/init-db';
+import { initDatabase } from '@/lib/server/db';
 import { AppDataSource } from '@/lib/db.server';
 import { NextResponse } from 'next/server';
 
@@ -12,8 +12,8 @@ export async function GET() {
       dbInitialized = true;
     } else {
       console.log('Health check: Database not initialized, triggering initialization...');
-      const result = await initializeDatabase();
-      dbInitialized = !!result;
+      await initDatabase();
+      dbInitialized = AppDataSource?.isInitialized || false;
     }
 
     const responseTime = Date.now() - startTime;

--- a/lib/server/db.ts
+++ b/lib/server/db.ts
@@ -1,0 +1,15 @@
+import 'reflect-metadata';
+import { AppDataSource } from '../db.server';
+
+let initialized = false;
+
+export async function initDatabase() {
+  if (initialized) return;
+
+  console.log('[DB] Initializing database…');
+
+  await AppDataSource.initialize();
+
+  console.log('[DB] Database initialized');
+  initialized = true;
+}


### PR DESCRIPTION
- Create lib/server/db.ts with initDatabase() function
- Update all API routes to call initDatabase() directly
- Remove lazy initialization conditions that prevented migrations
- Fix issue where AppDataSource.initialize() was never called in runtime