### PR TITLE
fix: add JS wrapper for DB initialization in server.js

### DIFF
--- a/lib/init-db.js
+++ b/lib/init-db.js
@@ -1,0 +1,50 @@
+// JavaScript wrapper for TypeScript database initialization
+// This file exists as a bridge between server.js (JS) and TypeScript modules
+
+const { AppDataSource } = require('./db.server');
+
+let initialized = false;
+
+async function initializeDatabase() {
+  if (initialized) {
+    console.log('[BOOT] Database already initialized, skipping');
+    return AppDataSource;
+  }
+
+  console.log('[BOOT] Initializing database...');
+
+  try {
+    if (!AppDataSource) {
+      throw new Error('AppDataSource is null - database configuration failed');
+    }
+
+    if (!AppDataSource.isInitialized) {
+      await AppDataSource.initialize();
+      console.log('[BOOT] Database connection established successfully');
+
+      // Verify tables exist
+      const queryRunner = AppDataSource.createQueryRunner();
+      const tables = await queryRunner.query('SHOW TABLES');
+      const tableNames = tables.map((row) => Object.values(row)[0]);
+
+      if (!tableNames.includes('Author') || !tableNames.includes('Analysis')) {
+        console.error('[BOOT] Migration verification failed: Required tables do not exist');
+        await queryRunner.release();
+        throw new Error('Required database tables not found');
+      }
+
+      await queryRunner.release();
+      console.log('[BOOT] Migration verification successful');
+    }
+
+    initialized = true;
+    console.log('[BOOT] Database initialization completed');
+    return AppDataSource;
+
+  } catch (error) {
+    console.error('[BOOT] Database initialization failed:', error.message);
+    throw error;
+  }
+}
+
+module.exports = { initializeDatabase, AppDataSource };

--- a/lib/init-db.js
+++ b/lib/init-db.js
@@ -1,6 +1,7 @@
 // JavaScript wrapper for TypeScript database initialization
 // This file exists as a bridge between server.js (JS) and TypeScript modules
 
+/* eslint-disable @typescript-eslint/no-require-imports */
 const { AppDataSource } = require('./db.server');
 
 let initialized = false;


### PR DESCRIPTION
- Add lib/init-db.js as JavaScript bridge between server.js and TypeScript modules
- server.js can now successfully require('./lib/init-db') in Docker container
- Fix MODULE_NOT_FOUND error when starting with custom server

This resolves the Docker bootstrap issue where server.js couldn't load TypeScript modules.