### PR TITLE
fix: add eslint-disable for require() in JS wrapper

### DIFF
--- a/lib/init-db.js
+++ b/lib/init-db.js
@@ -1,6 +1,7 @@
 // JavaScript wrapper for TypeScript database initialization
 // This file exists as a bridge between server.js (JS) and TypeScript modules
 
+/* eslint-disable @typescript-eslint/no-require-imports */
 const { AppDataSource } = require('./db.server');
 
 let initialized = false;


### PR DESCRIPTION
- Add eslint-disable comment to lib/init-db.js
- Fix linting error for require() imports in JavaScript file
- Maintain compatibility with server.js imports