### PR TITLE
fix: resolve module resolution error for db.server in Docker container

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,0 @@
-# Generated JavaScript files from TypeScript compilation
-lib/**/*.js
-migrations/**/*.js

--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,3 @@
+# Generated JavaScript files from TypeScript compilation
+lib/**/*.js
+migrations/**/*.js

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -43,7 +43,11 @@
     ]
   },
   "ignorePatterns": [
-    "app/generated/**"
+    "app/generated/**",
+    "lib/db.server.js",
+    "lib/entities/*.js",
+    "lib/migrations/*.js",
+    "migrations/*.js"
   ],
   "overrides": [
     {
@@ -62,6 +66,12 @@
         "@typescript-eslint/no-this-alias": "off",
         "@typescript-eslint/no-unused-expressions": "off",
         "@typescript-eslint/no-unused-vars": "off"
+      }
+    },
+    {
+      "files": ["lib/**/*.js"],
+      "rules": {
+        "@typescript-eslint/no-require-imports": "off"
       }
     }
   ]

--- a/.gitignore
+++ b/.gitignore
@@ -86,6 +86,12 @@ tmp/
 # build artifacts
 build-casn.tgz
 
+# generated JavaScript files from TypeScript compilation
+lib/db.server.js
+lib/entities/*.js
+lib/migrations/*.js
+migrations/*.js
+
 # database dumps
 *.sql
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   },
   "scripts": {
     "dev": "next dev",
-    "build": "next build",
+    "build": "npm run build:lib && next build",
+    "build:lib": "tsc lib/db.server.ts --outDir . --target ES2022 --module commonjs --moduleResolution node --esModuleInterop --allowSyntheticDefaultImports --skipLibCheck",
     "prebuild": "bash scripts/check-posts.sh",
     "postbuild": "node scripts/prepare-tmp.js",
     "start": "next start -p $PORT",


### PR DESCRIPTION
- Add TypeScript compilation step for lib files to generate CommonJS modules
- Compile db.server.ts to db.server.js so require() can load it in init-db.js
- Update build script to run lib compilation before Next.js build
- Fixes 'Cannot find module ./db.server' error in production container