### PR TITLE
fix: update validation workflow to use TypeORM instead of Prisma

### DIFF
--- a/.github/workflows/prisma-validation.yml
+++ b/.github/workflows/prisma-validation.yml
@@ -1,4 +1,4 @@
-name: Prisma v7 Configuration Validation
+name: Docker Deployment Configuration Validation
 
 on:
   pull_request:
@@ -12,33 +12,33 @@ permissions:
 
 
 jobs:
-  validate-prisma-config:
+  validate-docker-config:
     runs-on: ubuntu-latest
-    
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
-        
-      - name: Validate Prisma v7 Configuration
+
+      - name: Validate Docker Deployment Configuration
         run: |
-          echo "🔍 === PRISMA V7 CONFIGURATION VALIDATION ==="
-          
+          echo "🔍 === DOCKER DEPLOYMENT CONFIGURATION VALIDATION ==="
+
           # Make test script executable
-          chmod +x test-prisma-config.sh
-          
+          chmod +x test-typeorm-config.sh
+
           # Run the validation script
-          if ./test-prisma-config.sh; then
-            echo "✅ Prisma v7 configuration validation PASSED"
+          if ./test-typeorm-config.sh; then
+            echo "✅ Docker deployment configuration validation PASSED"
             exit 0
           else
-            echo "❌ Prisma v7 configuration validation FAILED"
+            echo "❌ Docker deployment configuration validation FAILED"
             exit 1
           fi
-          
+
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: prisma-validation-results
-          path: test-prisma-config.sh
+          name: docker-validation-results
+          path: test-typeorm-config.sh
           retention-days: 30


### PR DESCRIPTION
- Rename workflow from 'Prisma v7 Configuration Validation' to 'Docker Deployment Configuration Validation'
- Change job name from validate-prisma-config to validate-docker-config
- Update script from test-prisma-config.sh to test-typeorm-config.sh
- Update artifact names to be generic (docker-validation-results)
- Update validation messages to be generic Docker deployment validation

This fixes the validation failure since the project uses TypeORM, not Prisma.