### PR TITLE
chore(deps): ignore incompatible major updates for Strapi peer deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,6 +16,16 @@ updates:
     commit-message:
       prefix: "chore(deps)"
       include: "scope"
+    ignore:
+      - dependency-name: "react"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "react-dom"
+        update-types:
+          - "version-update:semver-major"
+      - dependency-name: "react-router-dom"
+        update-types:
+          - "version-update:semver-major"
   - package-ecosystem: "npm"
     directory: "/"
     target-branch: "dev"


### PR DESCRIPTION
## Summary
- add Dependabot ignore rules for major updates of `react`, `react-dom`, and `react-router-dom` in `/strapi`
- keep Dependabot updates within ranges currently compatible with `@strapi/strapi@5.36.1`

## Why
Current major bumps (`react@19`, `react-dom@19`, `react-router-dom@7`) are not compatible with Strapi peer requirements and repeatedly fail `strapi-smoke` CI.