### PR TITLE
chore(deps): ignore eslint major updates in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -41,3 +41,7 @@ updates:
     commit-message:
       prefix: "chore(deps)"
       include: "scope"
+    ignore:
+      - dependency-name: "eslint"
+        update-types:
+          - "version-update:semver-major"


### PR DESCRIPTION
## Summary
- add Dependabot ignore rule for major `eslint` updates in `/`

## Why
`eslint-config-next@15.4.6` allows `eslint` only up to `^9`, so `eslint@10` PRs fail dependency resolution in CI.