### PR TITLE
chore(deps): disable Dependabot auto-rebase

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,6 +3,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/strapi"
     target-branch: "dev"
+    rebase-strategy: "disabled"
     schedule:
       interval: "weekly"
       day: "monday"
@@ -29,6 +30,7 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     target-branch: "dev"
+    rebase-strategy: "disabled"
     schedule:
       interval: "monthly"
       day: "monday"


### PR DESCRIPTION
## Summary
- set `rebase-strategy: "disabled"` for both npm update groups in `.github/dependabot.yml`

## Why
- stops Dependabot from automatically rebasing its PR branches.