### PR TITLE
chore(deps): ignore eslint-config-next major updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -47,3 +47,6 @@ updates:
       - dependency-name: "eslint"
         update-types:
           - "version-update:semver-major"
+      - dependency-name: "eslint-config-next"
+        update-types:
+          - "version-update:semver-major"


### PR DESCRIPTION
## Summary
- add Dependabot ignore rule for major updates of `eslint-config-next`

## Why
`eslint-config-next@16.x` is not compatible with the current ESLint setup in this repo and fails lint CI with a config parsing error.