### PR TITLE
chore: update contact email

### DIFF
--- a/app/kontakt/ContactSection.tsx
+++ b/app/kontakt/ContactSection.tsx
@@ -12,11 +12,11 @@ export function ContactSection() {
               </div>
               <p className="text-muted mb-0">
                 <a
-                  href="mailto:p.balcerowski@sluzbaniepodleglej.pl"
+                  href="mailto:fundacja@sluzbaniepodleglej.pl"
                   className="text-muted"
                   style={{ textDecoration: 'none' }}
                 >
-                  p.balcerowski@sluzbaniepodleglej.pl
+                  fundacja@sluzbaniepodleglej.pl
                 </a>
               </p>
             </div>

--- a/components/EmailLinkClient.tsx
+++ b/components/EmailLinkClient.tsx
@@ -3,11 +3,11 @@
 export function EmailLinkClient() {
   return (
     <a
-      href="mailto:p.balcerowski@sluzbaniepodleglej.pl"
+      href="mailto:fundacja@sluzbaniepodleglej.pl"
       className="text-muted"
       style={{ textDecoration: 'none' }}
     >
-      p.balcerowski@sluzbaniepodleglej.pl
+      fundacja@sluzbaniepodleglej.pl
     </a>
   );
 }

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -123,7 +123,7 @@ export default function Header() {
                 }}
               >
                 <EmailLink
-                  email="p.balcerowski@sluzbaniepodleglej.pl"
+                  email="fundacja@sluzbaniepodleglej.pl"
                   ariaLabel="Wyślij email do Piotra Balcerowskiego"
                   className="text-white"
                   iconClass="mdi mdi-email mr-1 text-custom"

--- a/cypress/e2e/hydration.cy.ts
+++ b/cypress/e2e/hydration.cy.ts
@@ -311,7 +311,7 @@ describe('Hydration Tests', () => {
     cy.get('a[href*="mailto:"]').should('exist').and('be.visible');
 
     // Verify the email text is properly restored by our client component
-    cy.get('a[href*="mailto:"]').should('contain', 'p.balcerowski@sluzbaniepodleglej.pl');
+    cy.get('a[href*="mailto:"]').should('contain', 'fundacja@sluzbaniepodleglej.pl');
 
     // Verify no data-cfemail attributes exist (Cloudflare protection markers)
     cy.get('[data-cfemail]').should('not.exist');

--- a/test/integration/pages/KontaktPage.test.tsx
+++ b/test/integration/pages/KontaktPage.test.tsx
@@ -42,9 +42,9 @@ try {
   it('renderuje informacje kontaktowe - email', () => {
     render(<PageComponent />);
 
-    const emailLink = screen.getByRole('link', { name: /p\.balcerowski@sluzbaniepodleglej\.pl/ });
+    const emailLink = screen.getByRole('link', { name: /fundacja@sluzbaniepodleglej\.pl/ });
     expect(emailLink).toBeInTheDocument();
-    expect(emailLink).toHaveAttribute('href', 'mailto:p.balcerowski@sluzbaniepodleglej.pl');
+    expect(emailLink).toHaveAttribute('href', 'mailto:fundacja@sluzbaniepodleglej.pl');
   });
 
   it('renderuje informacje kontaktowe - strona www', () => {

--- a/test/unit/components/Header.test.tsx
+++ b/test/unit/components/Header.test.tsx
@@ -104,8 +104,8 @@ try {
     // Sprawdź czy jest link do email
     const emailLink = screen.queryByRole('link', { name: /wyślij email/i });
     if (emailLink) {
-      expect(emailLink).toHaveAttribute('href', 'mailto:p.balcerowski@sluzbaniepodleglej.pl');
-      expect(emailLink).toHaveTextContent('p.balcerowski@sluzbaniepodleglej.pl');
+      expect(emailLink).toHaveAttribute('href', 'mailto:fundacja@sluzbaniepodleglej.pl');
+      expect(emailLink).toHaveTextContent('fundacja@sluzbaniepodleglej.pl');
     }
   });
 });


### PR DESCRIPTION
## Summary
- replace the public contact email with `fundacja@sluzbaniepodleglej.pl`
- update header, contact section and email link client to use the new address
- align unit, integration and hydration tests with the new mailto target

## Verification
- npm test -- --runTestsByPath test/unit/components/Header.test.tsx test/integration/pages/KontaktPage.test.tsx