### PR TITLE
fix(ui): normalize analyses header and card dimensions

### DIFF
--- a/app/analizy/page.tsx
+++ b/app/analizy/page.tsx
@@ -1,10 +1,10 @@
 // app/analizy/page.tsx
 import React from "react";
 import Link from "next/link";
-import Image, { getImageProps } from "next/image";
+import Image from "next/image";
 import type { Metadata } from "next";
-import type { CSSProperties } from "react";
 import { getAnalyses } from "@/lib/analyses";
+import Hero from "@/components/Hero";
 
 export const runtime = "nodejs";
 export const dynamic = "force-dynamic"; // Build-safe shell; content comes from tag-invalidated DB cache
@@ -43,77 +43,16 @@ export default async function AnalysesPage() {
       if (bTime !== aTime) return bTime - aTime;
       return a.title.localeCompare(b.title, "pl");
     });
-    const heroMediaStyle = {
-      '--hero-background-position': 'center 35%',
-    } as CSSProperties;
-    const {
-      props: { srcSet: mobileHeroSrcSet },
-    } = getImageProps({
-      src: "/images/logo.jpg",
-      alt: "",
-      width: 2000,
-      height: 2000,
-      sizes: "100vw",
-      quality: 68,
-      loading: "eager",
-      fetchPriority: "high",
-      decoding: "async",
-    });
-    const {
-      props: { srcSet: desktopHeroSrcSet, src: desktopHeroSrc, ...desktopHeroImgProps },
-    } = getImageProps({
-      src: "/images/home2.webp",
-      alt: "",
-      width: 1225,
-      height: 560,
-      sizes: "100vw",
-      quality: 74,
-      loading: "eager",
-      fetchPriority: "high",
-      decoding: "async",
-    });
 
     return (
       <main className="bg-gray-100 min-h-screen pb-12">
-        {/* HEADER START */}
-        <section className="contact-us-home section" id="home">
-          <picture className="hero-picture" style={heroMediaStyle}>
-            <source media="(max-width: 768px)" srcSet={mobileHeroSrcSet} />
-            <img
-              {...desktopHeroImgProps}
-              src={desktopHeroSrc}
-              srcSet={desktopHeroSrcSet}
-              alt=""
-              className="hero-bg"
-            />
-          </picture>
-        </section>
-
-        <div className="bg-overlay"></div>
-        <div className="home-center">
-          <div className="home-desc-center">
-            <div className="container">
-              <div className="row justify-content-center">
-                <div className="col-lg-8" style={{ background: "rgba(30, 30, 30, 0.65)" }}>
-                  <div className="home-page-title text-center">
-                    <h1 className="text-white mb-2">Analizy</h1>
-                    <nav aria-label="breadcrumb">
-                      <ol className="breadcrumb justify-content-center bg-transparent">
-                        <li className="breadcrumb-item text-white">
-                          <Link href="/" className="text-white">Strona główna</Link>
-                        </li>
-                        <li className="breadcrumb-item active" aria-current="page">
-                          <Link href="/analizy" className="text-custom">Analizy</Link>
-                        </li>
-                      </ol>
-                    </nav>
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-        </div>
-        {/* HEADER END */}
+        <Hero
+          title="Analizy"
+          breadcrumbs={[
+            { label: "Strona główna", href: "/" },
+            { label: "Analizy", href: "/analizy", active: true },
+          ]}
+        />
 
         {/* ANALYSES LIST START */}
         <section className="section">
@@ -160,25 +99,27 @@ export default async function AnalysesPage() {
 
                 <div className="row projects-wrapper">
                   {sortedAnalyses.map((analysis) => (
-                    <div className="col-lg-4 col-md-6 management international" key={analysis.id}>
-                      <div className="blog-list-item bg-white rounded mt-4">
-                        <div className="blog-list-img">
+                    <div className="col-lg-4 col-md-6 management international analyses-grid-item" key={analysis.id}>
+                      <div className="blog-list-item bg-white rounded analyses-card d-flex flex-column h-100">
+                        <div className="blog-list-img analyses-card-image">
                           <Image
                             src={analysis.author?.img || "/images/placeholder.png"}
-                            width={300}
-                            height={300}
-                            className="img-fluid d-block mx-auto rounded"
+                            width={800}
+                            height={1000}
+                            className="d-block w-100 h-100"
+                            sizes="(min-width: 992px) 33vw, (min-width: 768px) 50vw, 100vw"
+                            style={{ objectFit: "cover", objectPosition: "center top" }}
                             alt={analysis.author?.name || "Autor"}
                           />
                           <div className="blog-list-overlay"></div>
                         </div>
-                        <div className="cases-desc text-center p-3">
-                          <h5 className="cases-subtitle mb-2">
+                        <div className="cases-desc text-center p-3 analyses-card-content">
+                          <h5 className="cases-subtitle mb-2 analyses-card-title">
                             <Link href={`/analizy/${analysis.slug}`} className="text-dark">
                               {analysis.title}
                             </Link>
                           </h5>
-                          <p className="text-muted">
+                          <p className="text-muted mb-0 analyses-card-author">
                             {analysis.author?.slug && analysis.author?.name ? (
                               <Link href={`/autor/${analysis.author.slug}`} className="text-custom">
                                 {analysis.author.name}
@@ -188,7 +129,7 @@ export default async function AnalysesPage() {
                             )}
                           </p>
                         </div>
-                        <div className="learn-more text-center">
+                        <div className="learn-more text-center mt-auto">
                           <Link href={`/analizy/${analysis.slug}`} className="btn btn-custom btn-block">
                             PRZECZYTAJ
                           </Link>

--- a/app/globals.css
+++ b/app/globals.css
@@ -50,3 +50,41 @@ h1, h2, h3, h4, h5, h6,
     color-scheme: dark;
   }
 }
+
+/* Analyses page: keep cards visually consistent regardless of title length */
+.analyses-grid-item {
+  display: flex;
+}
+
+.analyses-card {
+  width: 100%;
+  margin-top: 1.5rem;
+  overflow: hidden;
+}
+
+.analyses-card-image {
+  aspect-ratio: 4 / 3;
+  background-color: #f3f4f6;
+}
+
+.analyses-card-content {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+}
+
+.analyses-card-title {
+  min-height: 5.4rem;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.analyses-card-author {
+  min-height: 3.2rem;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}


### PR DESCRIPTION
## Co poprawia ten PR
- unifikuje nagłówek `/analizy` z resztą serwisu przez użycie wspólnego komponentu `Hero` (ten sam układ co `/autorzy`),
- wyrównuje wysokość kafelków analiz w siatce:
  - stały układ flex kart,
  - kontrola wysokości sekcji tytułu i autora (`line-clamp`),
  - spójny obszar grafiki.

## Problem
Na `/analizy` nagłówek był wizualnie niespójny względem `/autorzy`, a kafelki miały różne wysokości przy dłuższych tytułach.

## Testy
- `npm run test -- test/integration/pages/analyses-comprehensive.test.tsx`
- `npm run type-check`
