### PR TITLE
fix(ui): reduce analyses image cropping

### DIFF
--- a/app/analizy/page.tsx
+++ b/app/analizy/page.tsx
@@ -108,7 +108,7 @@ export default async function AnalysesPage() {
                             height={1000}
                             className="d-block w-100 h-100"
                             sizes="(min-width: 992px) 33vw, (min-width: 768px) 50vw, 100vw"
-                            style={{ objectFit: "cover", objectPosition: "center top" }}
+                            style={{ objectFit: "contain", objectPosition: "center center" }}
                             alt={analysis.author?.name || "Autor"}
                           />
                           <div className="blog-list-overlay"></div>

--- a/app/globals.css
+++ b/app/globals.css
@@ -63,7 +63,7 @@ h1, h2, h3, h4, h5, h6,
 }
 
 .analyses-card-image {
-  aspect-ratio: 4 / 3;
+  aspect-ratio: 4 / 5;
   background-color: #f3f4f6;
 }
 


### PR DESCRIPTION
## Co
- zmiana renderu miniatur na `/analizy` z `object-fit: cover` na `object-fit: contain`,
- zmiana proporcji kontenera obrazu z `4/3` na `4/5`.

## Efekt
- brak agresywnego przycinania twarzy,
- zachowana równa wysokość kafelków.

## Testy
- `npm run test -- test/integration/pages/AnalysesPage.live.test.tsx test/integration/pages/analyses-comprehensive.test.tsx`
- `npm run type-check`
