### PR TITLE
Fix analizy cards: title wrapping and card spacing

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -52,13 +52,19 @@ h1, h2, h3, h4, h5, h6,
 }
 
 /* Analyses page: keep cards visually consistent regardless of title length */
+.projects-wrapper {
+  row-gap: 1.5rem;
+}
+
 .analyses-grid-item {
   display: flex;
+  padding-left: 15px;
+  padding-right: 15px;
 }
 
 .analyses-card {
   width: 100%;
-  margin-top: 1.5rem;
+  margin-top: 0;
   overflow: hidden;
 }
 
@@ -71,20 +77,22 @@ h1, h2, h3, h4, h5, h6,
   display: flex;
   flex: 1;
   flex-direction: column;
+  gap: 0.75rem;
 }
 
 .analyses-card-title {
-  min-height: 5.4rem;
-  display: -webkit-box;
-  -webkit-line-clamp: 3;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
+  min-height: 6.2rem;
+  line-height: 1.35;
+  margin-bottom: 0;
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
+.analyses-card-title a {
+  display: block;
 }
 
 .analyses-card-author {
-  min-height: 3.2rem;
-  display: -webkit-box;
-  -webkit-line-clamp: 2;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
+  min-height: 2rem;
+  margin-top: auto;
 }


### PR DESCRIPTION
## Co poprawia ten PR
- usuwa twarde ucinanie tytułów analiz (`line-clamp`) i pozwala na pełne zawijanie
- stabilizuje wysokości sekcji tekstowej kart (`min-height`, `line-height`, `overflow-wrap`)
- dodaje stałe odstępy między kartami w siatce analiz (`row-gap`)
- utrzymuje czytelny układ autora i CTA przy dłuższych tytułach

## Zakres
- `app/globals.css`

## Weryfikacja
- ręczna kontrola układu `/analizy`
- build lokalny nie został uruchomiony (brak `tsc` w środowisku roboczym)